### PR TITLE
fix(core): address design deficiencies across cache, events, lifecycle, log, and jwt

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -95,7 +95,11 @@ func New(name string, opts *Options) (*Cache, error) {
 	}, nil
 }
 
-// Set stores a key-value pair in the cache with the given TTL
+// Set stores a key-value pair in the cache with the given TTL.
+//
+// The write is processed asynchronously by Ristretto's internal buffer,
+// so a subsequent Get may not immediately reflect the new value.
+// Use SetSync when the caller requires read-your-writes consistency.
 func (c *Cache) Set(key interface{}, value interface{}, ttl time.Duration) error {
 	if ttl < 0 {
 		return ErrInvalidTTL
@@ -103,23 +107,34 @@ func (c *Cache) Set(key interface{}, value interface{}, ttl time.Duration) error
 
 	cost := int64(1)
 	if ttl == 0 {
-		// No expiration
 		if !c.cache.Set(key, value, cost) {
 			return ErrCacheSet
 		}
 	} else {
-		// With TTL
 		if !c.cache.SetWithTTL(key, value, cost, ttl) {
 			return ErrCacheSet
 		}
 	}
+	return nil
+}
 
-	// Wait for the value to be processed
+// SetSync stores a key-value pair and blocks until Ristretto has processed
+// all pending writes, providing read-your-writes consistency.
+//
+// Use this only when you must immediately read back the value you just wrote.
+// For bulk insertions, prefer SetMulti which calls Wait once for all items.
+func (c *Cache) SetSync(key interface{}, value interface{}, ttl time.Duration) error {
+	if err := c.Set(key, value, ttl); err != nil {
+		return err
+	}
 	c.cache.Wait()
 	return nil
 }
 
-// SetWithCost stores a key-value pair with a custom cost
+// SetWithCost stores a key-value pair with a custom cost.
+//
+// The write is processed asynchronously. Use SetWithCostSync for
+// read-your-writes consistency.
 func (c *Cache) SetWithCost(key interface{}, value interface{}, cost int64, ttl time.Duration) error {
 	if ttl < 0 {
 		return ErrInvalidTTL
@@ -134,7 +149,15 @@ func (c *Cache) SetWithCost(key interface{}, value interface{}, cost int64, ttl 
 			return ErrCacheSet
 		}
 	}
+	return nil
+}
 
+// SetWithCostSync stores a key-value pair with a custom cost and blocks until
+// Ristretto has processed all pending writes.
+func (c *Cache) SetWithCostSync(key interface{}, value interface{}, cost int64, ttl time.Duration) error {
+	if err := c.SetWithCost(key, value, cost, ttl); err != nil {
+		return err
+	}
 	c.cache.Wait()
 	return nil
 }
@@ -196,7 +219,9 @@ func (c *Cache) GetMulti(keys []interface{}) map[interface{}]interface{} {
 	return result
 }
 
-// SetMulti stores multiple key-value pairs in the cache
+// SetMulti stores multiple key-value pairs in the cache and blocks until
+// Ristretto has processed all pending writes (single Wait for all items).
+// This is more efficient than calling SetSync in a loop.
 func (c *Cache) SetMulti(items map[interface{}]interface{}, ttl time.Duration) error {
 	if ttl < 0 {
 		return ErrInvalidTTL

--- a/events/types.go
+++ b/events/types.go
@@ -8,6 +8,24 @@ import (
 	"time"
 )
 
+// initSalt is a process-level random salt computed once at startup.
+// It provides sufficient randomness to prevent ID collisions across processes
+// without paying the cost of a crypto/rand call for every event.
+var initSalt string
+
+func init() {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback: encode the current nanosecond timestamp as hex.
+		ts := time.Now().UnixNano()
+		b = []byte{
+			byte(ts), byte(ts >> 8), byte(ts >> 16), byte(ts >> 24),
+			byte(ts >> 32), byte(ts >> 40), byte(ts >> 48), byte(ts >> 56),
+		}
+	}
+	initSalt = hex.EncodeToString(b)
+}
+
 // EventType represents the type of event in the Lynx system
 type EventType uint32
 
@@ -152,22 +170,26 @@ func NewLynxEvent(eventType EventType, pluginID, source string) LynxEvent {
 }
 
 var (
-	// eventIDCounter ensures unique event IDs even in high concurrency scenarios
+	// eventIDCounter is an atomically-incremented counter that guarantees
+	// strict ordering and uniqueness within a single process.
 	eventIDCounter atomic.Uint64
 )
 
-// generateEventID generates a unique event ID for deduplication
-// Format: {pluginID}-{eventType}-{timestamp}-{nanosecond}-{randomHex}-{counter}
-// This ensures uniqueness even when multiple events are generated in the same nanosecond
+// generateEventID generates a unique event ID for deduplication.
+//
+// Format: {pluginID}-{eventType}-{unixSec}-{nano}-{initSalt}-{counter}
+//
+// Uniqueness guarantee:
+//   - initSalt (16 hex chars, random at process start) prevents collisions
+//     across different process instances sharing the same nanosecond clock.
+//   - counter monotonically increases within the process, preventing collisions
+//     even when multiple events are created in the same nanosecond.
+//
+// This replaces the previous approach that called crypto/rand on every event,
+// which caused unnecessary syscall overhead in high-throughput scenarios.
 func generateEventID(pluginID string, eventType EventType, t time.Time) string {
 	counter := eventIDCounter.Add(1)
-	randomBytes := make([]byte, 4)
-	if _, err := rand.Read(randomBytes); err != nil {
-		// Fallback: use counter as random component if crypto/rand fails
-		randomBytes = []byte{byte(counter), byte(counter >> 8), byte(counter >> 16), byte(counter >> 24)}
-	}
-	randomHex := hex.EncodeToString(randomBytes)
-	return fmt.Sprintf("%s-%d-%d-%d-%s-%d", pluginID, eventType, t.Unix(), t.Nanosecond(), randomHex, counter)
+	return fmt.Sprintf("%s-%d-%d-%d-%s-%d", pluginID, eventType, t.Unix(), t.Nanosecond(), initSalt, counter)
 }
 
 // WithPriority sets the event priority

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -576,66 +576,58 @@ func (m *DefaultPluginManager[T]) safeInitPlugin(p plugins.Plugin, rt plugins.Ru
 	return err
 }
 
-// emitPluginEvent emits a plugin event to the unified event system
+// lynxToPluginEventEntry maps an events.EventType to its corresponding
+// plugins.EventType string and PluginStatus for observability.
+type lynxToPluginEventEntry struct {
+	pluginEventType plugins.EventType
+	status          plugins.PluginStatus
+}
+
+// lynxToPluginEventTable is the single source-of-truth mapping between
+// the unified events.EventType (uint32) and the plugin-level
+// plugins.EventType (string) + PluginStatus pair.
+// Adding a new event type only requires one entry here.
+var lynxToPluginEventTable = map[events.EventType]lynxToPluginEventEntry{
+	events.EventPluginInitializing: {plugins.EventPluginInitializing, plugins.StatusInitializing},
+	events.EventPluginInitialized:  {plugins.EventPluginInitialized, plugins.StatusInactive},
+	events.EventPluginStarting:     {plugins.EventPluginStarting, plugins.StatusInitializing},
+	events.EventPluginStarted:      {plugins.EventPluginStarted, plugins.StatusActive},
+	events.EventPluginStopping:     {plugins.EventPluginStopping, plugins.StatusStopping},
+	events.EventPluginStopped:      {plugins.EventPluginStopped, plugins.StatusTerminated},
+	events.EventErrorOccurred:      {plugins.EventErrorOccurred, plugins.StatusFailed},
+}
+
+// defaultLynxToPluginEventEntry is returned for any event type that is not
+// explicitly listed in lynxToPluginEventTable.
+var defaultLynxToPluginEventEntry = lynxToPluginEventEntry{
+	pluginEventType: plugins.EventPluginInitializing,
+	status:          plugins.StatusInactive,
+}
+
+// emitPluginEvent emits a plugin event to the unified event system.
+// It converts events.EventType to plugins.EventType and derives the
+// approximate PluginStatus using lynxToPluginEventTable.
 func (m *DefaultPluginManager[T]) emitPluginEvent(pluginID string, eventType events.EventType, metadata map[string]any) {
 	if m.runtime == nil {
 		return
 	}
 
-	// Convert events.EventType to plugins.EventType
-	var pluginEventType plugins.EventType
-	switch eventType {
-	case events.EventPluginInitializing:
-		pluginEventType = plugins.EventPluginInitializing
-	case events.EventPluginInitialized:
-		pluginEventType = plugins.EventPluginInitialized
-	case events.EventPluginStarting:
-		pluginEventType = plugins.EventPluginStarting
-	case events.EventPluginStarted:
-		pluginEventType = plugins.EventPluginStarted
-	case events.EventPluginStopping:
-		pluginEventType = plugins.EventPluginStopping
-	case events.EventPluginStopped:
-		pluginEventType = plugins.EventPluginStopped
-	case events.EventErrorOccurred:
-		pluginEventType = plugins.EventErrorOccurred
-	default:
-		pluginEventType = plugins.EventPluginInitializing
+	entry, ok := lynxToPluginEventTable[eventType]
+	if !ok {
+		entry = defaultLynxToPluginEventEntry
 	}
 
-	// Create plugin event
-	// Derive an approximate status from event type for better observability
-	var status plugins.PluginStatus
-	switch eventType {
-	case events.EventPluginInitializing:
-		status = plugins.StatusInitializing
-	case events.EventPluginInitialized:
-		status = plugins.StatusInactive
-	case events.EventPluginStarting:
-		status = plugins.StatusInitializing
-	case events.EventPluginStarted:
-		status = plugins.StatusActive
-	case events.EventPluginStopping:
-		status = plugins.StatusStopping
-	case events.EventPluginStopped:
-		status = plugins.StatusTerminated
-	case events.EventErrorOccurred:
-		status = plugins.StatusFailed
-	default:
-		status = plugins.StatusInactive
-	}
 	pluginEvent := plugins.PluginEvent{
-		Type:      pluginEventType,
+		Type:      entry.pluginEventType,
 		Priority:  plugins.PriorityNormal,
 		Source:    "plugin-manager",
 		Category:  "lifecycle",
 		PluginID:  pluginID,
-		Status:    status,
+		Status:    entry.status,
 		Timestamp: time.Now().Unix(),
 		Metadata:  metadata,
 	}
 
-	// Emit through runtime
 	m.runtime.EmitEvent(pluginEvent)
 }
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -263,37 +262,20 @@ func InitLogger(name string, host string, version string, cfg kconf.Config) erro
 
 	// Configure console output with optimizations
 	if logConfig.GetConsoleOutput() {
-		// Get format configuration
+		// Read format configuration directly from the proto-generated accessors.
 		formatType := "json" // default
-		consoleFormat := formatType
 		consoleColor := true
-
-		// Try to get format config using reflection (until proto is regenerated)
-		if formatVal := reflect.ValueOf(&logConfig).Elem(); formatVal.IsValid() {
-			if formatField := formatVal.FieldByName("Format"); formatField.IsValid() && formatField.CanInterface() {
-				formatPtr := formatField.Interface()
-				if formatPtr != nil {
-					formatReflect := reflect.ValueOf(formatPtr).Elem()
-					if formatReflect.IsValid() {
-						if formatTypeVal := formatReflect.FieldByName("Type"); formatTypeVal.IsValid() && formatTypeVal.CanInterface() {
-							if t, ok := formatTypeVal.Interface().(string); ok && t != "" {
-								formatType = t
-							}
-						}
-						if consoleFormatVal := formatReflect.FieldByName("ConsoleFormat"); consoleFormatVal.IsValid() && consoleFormatVal.CanInterface() {
-							if cf, ok := consoleFormatVal.Interface().(string); ok && cf != "" {
-								consoleFormat = cf
-							} else {
-								consoleFormat = formatType
-							}
-						}
-						if consoleColorVal := formatReflect.FieldByName("ConsoleColor"); consoleColorVal.IsValid() && consoleColorVal.CanInterface() {
-							if cc, ok := consoleColorVal.Interface().(bool); ok {
-								consoleColor = cc
-							}
-						}
-					}
-				}
+		if f := logConfig.GetFormat(); f != nil {
+			if t := f.GetType(); t != "" {
+				formatType = t
+			}
+			consoleColor = f.GetConsoleColor()
+		}
+		// Use a separate console format if specified; fall back to the file format type.
+		consoleFormat := formatType
+		if f := logConfig.GetFormat(); f != nil {
+			if cf := f.GetConsoleFormat(); cf != "" {
+				consoleFormat = cf
 			}
 		}
 
@@ -332,37 +314,13 @@ func InitLogger(name string, host string, version string, cfg kconf.Config) erro
 		if ma < 0 {
 			ma = 0 // 0 means no age-based removal
 		}
-		// Get new configuration fields (with fallback for compatibility)
-		// Note: These fields will be available after regenerating proto files
-		// For now, use reflection to access them if they exist
-		maxTotalSizeMB := 0
-		rotationStrategyStr := ""
-		rotationIntervalStr := ""
-
-		// Try to get new fields using reflection
-		// If proto file hasn't been regenerated, use defaults
-		configVal := reflect.ValueOf(&logConfig).Elem()
-		if configVal.IsValid() {
-			if field := configVal.FieldByName("MaxTotalSizeMb"); field.IsValid() && field.CanInterface() {
-				if val, ok := field.Interface().(int32); ok {
-					maxTotalSizeMB = int(val)
-				}
-			}
-			if field := configVal.FieldByName("RotationStrategy"); field.IsValid() && field.CanInterface() {
-				if val, ok := field.Interface().(string); ok {
-					rotationStrategyStr = val
-				}
-			}
-			if field := configVal.FieldByName("RotationInterval"); field.IsValid() && field.CanInterface() {
-				if val, ok := field.Interface().(string); ok {
-					rotationIntervalStr = val
-				}
-			}
-		}
-
+		// Read rotation configuration directly from the proto-generated accessors.
+		maxTotalSizeMB := int(logConfig.GetMaxTotalSizeMb())
 		if maxTotalSizeMB < 0 {
 			maxTotalSizeMB = 0 // 0 means unlimited
 		}
+		rotationStrategyStr := logConfig.GetRotationStrategy()
+		rotationIntervalStr := logConfig.GetRotationInterval()
 
 		// Determine rotation strategy
 		rotationStrategy := RotationStrategy(strings.ToLower(rotationStrategyStr))
@@ -411,41 +369,21 @@ func InitLogger(name string, host string, version string, cfg kconf.Config) erro
 		// Format configuration mainly affects console output
 		// This ensures log files remain parseable and searchable
 
-		// Get performance configuration with defaults
+		// Read performance configuration directly from the proto-generated accessors.
 		batchSize := 64 * 1024 // 64KB default
 		batchFlushInterval := 100 * time.Millisecond
 		asyncQueueSize := 2000       // default queue size
 		enableDynamicAdjust := false // default: disabled for stability
-
-		// Try to get performance config using reflection
-		perfConfigVal := reflect.ValueOf(&logConfig).Elem()
-		if perfConfigVal.IsValid() {
-			if perfField := perfConfigVal.FieldByName("Performance"); perfField.IsValid() && perfField.CanInterface() {
-				perfPtr := perfField.Interface()
-				if perfPtr != nil {
-					perfReflect := reflect.ValueOf(perfPtr).Elem()
-					if perfReflect.IsValid() {
-						if batchSizeVal := perfReflect.FieldByName("BatchSizeBytes"); batchSizeVal.IsValid() && batchSizeVal.CanInterface() {
-							if bs, ok := batchSizeVal.Interface().(int32); ok && bs > 0 {
-								batchSize = int(bs)
-							}
-						}
-						if flushIntervalVal := perfReflect.FieldByName("BatchFlushIntervalMs"); flushIntervalVal.IsValid() && flushIntervalVal.CanInterface() {
-							if fi, ok := flushIntervalVal.Interface().(int32); ok && fi > 0 {
-								batchFlushInterval = time.Duration(fi) * time.Millisecond
-							}
-						}
-						if queueSizeVal := perfReflect.FieldByName("AsyncQueueSize"); queueSizeVal.IsValid() && queueSizeVal.CanInterface() {
-							if qs, ok := queueSizeVal.Interface().(int32); ok && qs > 0 {
-								asyncQueueSize = int(qs)
-							}
-						}
-					}
-				}
-			}
-		}
-		// EnableDynamicAdjust from config (Performance.EnableDynamicAdjust / enable_dynamic_adjust)
 		if perf := logConfig.GetPerformance(); perf != nil {
+			if bs := perf.GetBatchSizeBytes(); bs > 0 {
+				batchSize = int(bs)
+			}
+			if fi := perf.GetBatchFlushIntervalMs(); fi > 0 {
+				batchFlushInterval = time.Duration(fi) * time.Millisecond
+			}
+			if qs := perf.GetAsyncQueueSize(); qs > 0 {
+				asyncQueueSize = int(qs)
+			}
 			enableDynamicAdjust = perf.GetEnableDynamicAdjust()
 		}
 

--- a/pkg/auth/jwt/jwt.go
+++ b/pkg/auth/jwt/jwt.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"crypto/ecdsa"
+	"crypto/rsa"
 	"errors"
 	"fmt"
 	"strings"
@@ -17,23 +18,29 @@ import (
 // Constraints: caller must implement Init, Valid, and Decoration, and also implement jwt.Claims.
 //
 // Example usage:
-//  type MyClaims struct { jwt.RegisteredClaims; ... }
-//  func (m *MyClaims) Init() error { ... }
-//  func (m *MyClaims) Valid() error { ... }
-//  func (m *MyClaims) Decoration() error { ... }
-//  func (m *MyClaims) GetExpirationTime() (*jwt.NumericDate, error) { return m.ExpiresAt, nil }
-//  ...
 //
-//  token, _ := jwt.Sign(&myClaims, "ES256", privateKey)
+//	type MyClaims struct { jwt.RegisteredClaims; ... }
+//	func (m *MyClaims) Init() error { ... }
+//	func (m *MyClaims) Valid() error { ... }
+//	func (m *MyClaims) Decoration() error { ... }
+//	func (m *MyClaims) GetExpirationTime() (*jwt.NumericDate, error) { return m.ExpiresAt, nil }
+//	...
 //
-//  ok, _ := jwt.Verify(token, &myClaims, *publicKey)
-//  ok, _ := jwt.VerifyWithAlg(token, &myClaims, *publicKey, "ES256")
-//  ok, _ := jwt.VerifyWithOptions(token, &myClaims, jwt.VerifyOptions{ExpectedAlg: "ES256", PublicKey: publicKey})
+//	// ECDSA
+//	token, _ := jwt.Sign(&myClaims, "ES256", privateKey)
+//	ok, _    := jwt.Verify(token, &myClaims, *publicKey)
+//
+//	// RSA
+//	token, _ := jwt.SignWithKey(&myClaims, jwt.RSAKey(rsaPrivateKey))
+//	ok, _    := jwt.VerifyWithKey(token, &myClaims, jwt.RSAPublicKey(rsaPublicKey))
+//
+//	// HMAC
+//	token, _ := jwt.SignWithKey(&myClaims, jwt.HMACKey([]byte("secret")))
+//	ok, _    := jwt.VerifyWithKey(token, &myClaims, jwt.HMACKey([]byte("secret")))
 //
 // Note: jwt refers to github.com/golang-jwt/jwt/v5.
 //
 //go:generate echo "This is a placeholder for possible future codegen"
-
 type CustomClaims interface {
 	Init() error
 	Valid() error
@@ -41,24 +48,154 @@ type CustomClaims interface {
 	jwt.Claims
 }
 
-// SignOptions Options for signing
+// ============================================================
+// SigningKey – algorithm-agnostic key abstraction
+// ============================================================
+
+// SigningKey wraps an algorithm name together with its signing and verification
+// keys so that callers do not have to repeat the algorithm string everywhere.
+type SigningKey interface {
+	// Algorithm returns the JWT signing algorithm name (e.g. "ES256", "RS256", "HS256").
+	Algorithm() string
+	// PrivateKey returns the key used for signing (may equal the public key for symmetric algorithms).
+	PrivateKey() interface{}
+	// PublicKey returns the key used for verification.
+	PublicKey() interface{}
+}
+
+// ECDSAKey builds a SigningKey from an ECDSA private key.
+// The public key is derived automatically; the algorithm is chosen based on
+// the curve size (P-256 → ES256, P-384 → ES384, P-521 → ES512).
+func ECDSAKey(priv *ecdsa.PrivateKey) SigningKey {
+	alg := ecdsaAlgorithm(&priv.PublicKey)
+	return &fixedSigningKey{alg: alg, priv: priv, pub: &priv.PublicKey}
+}
+
+// ECDSAPublicKey builds a verification-only SigningKey from an ECDSA public key.
+func ECDSAPublicKey(pub *ecdsa.PublicKey) SigningKey {
+	return &fixedSigningKey{alg: ecdsaAlgorithm(pub), pub: pub}
+}
+
+// RSAKey builds a SigningKey from an RSA private key.
+// The algorithm defaults to RS256; pass rsaKeyWithAlg to use RS384 or RS512.
+func RSAKey(priv *rsa.PrivateKey) SigningKey {
+	return &fixedSigningKey{alg: "RS256", priv: priv, pub: &priv.PublicKey}
+}
+
+// RSAKeyWithAlg builds a SigningKey from an RSA private key using the specified algorithm
+// ("RS256", "RS384", "RS512", "PS256", "PS384", "PS512").
+func RSAKeyWithAlg(priv *rsa.PrivateKey, alg string) SigningKey {
+	return &fixedSigningKey{alg: alg, priv: priv, pub: &priv.PublicKey}
+}
+
+// RSAPublicKey builds a verification-only SigningKey from an RSA public key (RS256).
+func RSAPublicKey(pub *rsa.PublicKey) SigningKey {
+	return &fixedSigningKey{alg: "RS256", pub: pub}
+}
+
+// RSAPublicKeyWithAlg builds a verification-only RSA SigningKey with the specified algorithm.
+func RSAPublicKeyWithAlg(pub *rsa.PublicKey, alg string) SigningKey {
+	return &fixedSigningKey{alg: alg, pub: pub}
+}
+
+// HMACKey builds a symmetric SigningKey from a raw secret (HS256).
+// For HS384 or HS512 use HMACKeyWithAlg.
+func HMACKey(secret []byte) SigningKey {
+	return &fixedSigningKey{alg: "HS256", priv: secret, pub: secret}
+}
+
+// HMACKeyWithAlg builds a symmetric SigningKey with the specified algorithm
+// ("HS256", "HS384", "HS512").
+func HMACKeyWithAlg(secret []byte, alg string) SigningKey {
+	return &fixedSigningKey{alg: alg, priv: secret, pub: secret}
+}
+
+// fixedSigningKey is the internal implementation of SigningKey.
+type fixedSigningKey struct {
+	alg  string
+	priv interface{}
+	pub  interface{}
+}
+
+func (k *fixedSigningKey) Algorithm() string    { return k.alg }
+func (k *fixedSigningKey) PrivateKey() interface{} { return k.priv }
+func (k *fixedSigningKey) PublicKey() interface{}  { return k.pub }
+
+// ecdsaAlgorithm selects the ECDSA algorithm name from the curve bit size.
+func ecdsaAlgorithm(pub *ecdsa.PublicKey) string {
+	switch pub.Curve.Params().BitSize {
+	case 384:
+		return "ES384"
+	case 521:
+		return "ES512"
+	default: // 256
+		return "ES256"
+	}
+}
+
+// ============================================================
+// SignOptions
+// ============================================================
+
+// SignOptions holds optional parameters for JWT signing.
 type SignOptions struct {
-	// Optional: set JWT header "kid" for key rotation
+	// Kid sets the JWT header "kid" field for key rotation.
 	Kid string
 }
 
 // ============================================================
-// Signing
+// Signing – algorithm-agnostic API (preferred)
 // ============================================================
-// Sign generates a JWT token
+
+// SignWithKey generates a JWT token using the provided SigningKey.
+// This is the preferred signing API as it supports ECDSA, RSA, and HMAC.
+func SignWithKey(c CustomClaims, key SigningKey) (string, error) {
+	return SignWithKeyAndOptions(c, key, nil)
+}
+
+// SignWithKeyAndOptions generates a JWT token with additional header options.
+func SignWithKeyAndOptions(c CustomClaims, key SigningKey, opts *SignOptions) (string, error) {
+	if err := c.Init(); err != nil {
+		return "", err
+	}
+	if err := c.Valid(); err != nil {
+		return "", err
+	}
+	m := jwt.GetSigningMethod(key.Algorithm())
+	if m == nil {
+		return "", fmt.Errorf("unsupported signing method: %s", key.Algorithm())
+	}
+	t := jwt.NewWithClaims(m, c)
+	if opts != nil && opts.Kid != "" {
+		t.Header["kid"] = opts.Kid
+	}
+	return t.SignedString(key.PrivateKey())
+}
+
+// VerifyWithKey validates a JWT token using the provided SigningKey.
+// This is the preferred verification API as it supports ECDSA, RSA, and HMAC.
+func VerifyWithKey(token string, c CustomClaims, key SigningKey) (bool, error) {
+	return VerifyWithOptions(token, c, VerifyOptions{
+		ExpectedAlg: key.Algorithm(),
+		verifyKey:   key.PublicKey(),
+	})
+}
+
+// ============================================================
+// Signing – ECDSA-only API (preserved for backward compatibility)
+// ============================================================
+
+// Sign generates a JWT token using ECDSA.
+//
+// Deprecated: use SignWithKey(c, ECDSAKey(privateKey)) instead, which
+// selects the algorithm automatically from the curve.
 func Sign(c CustomClaims, alg string, key *ecdsa.PrivateKey) (string, error) {
 	// Initialize custom claims
-	err := c.Init()
-	if err != nil {
+	if err := c.Init(); err != nil {
 		return "", err
 	}
 	// Validate custom claims
-	if err = c.Valid(); err != nil {
+	if err := c.Valid(); err != nil {
 		return "", err
 	}
 	m := jwt.GetSigningMethod(alg)
@@ -73,12 +210,16 @@ func Sign(c CustomClaims, alg string, key *ecdsa.PrivateKey) (string, error) {
 	return t.SignedString(key)
 }
 
-// SignJWT is a semantic alias for Sign
+// SignJWT is a semantic alias for Sign.
+//
+// Deprecated: use SignWithKey instead.
 func SignJWT(c CustomClaims, alg string, key *ecdsa.PrivateKey) (string, error) {
 	return Sign(c, alg, key)
 }
 
-// SignWithOptions supports setting header fields such as kid
+// SignWithOptions supports setting header fields such as kid.
+//
+// Deprecated: use SignWithKeyAndOptions(c, ECDSAKey(key), opts) instead.
 func SignWithOptions(c CustomClaims, alg string, key *ecdsa.PrivateKey, opts *SignOptions) (string, error) {
 	if err := c.Init(); err != nil {
 		return "", err
@@ -103,17 +244,18 @@ func SignWithOptions(c CustomClaims, alg string, key *ecdsa.PrivateKey, opts *Si
 // ============================================================
 // Errors and Decorators
 // ============================================================
+
 var (
-	// ErrUnexpectedSigningMethod is returned when the token signing method doesn't match expectation
+	// ErrUnexpectedSigningMethod is returned when the token signing method doesn't match expectation.
 	ErrUnexpectedSigningMethod = errors.New("unexpected signing method")
 )
 
-// Decorator is optional: if implemented, Decorate() is preferred; otherwise fall back to CustomClaims.Decoration()
+// Decorator is optional: if implemented, Decorate() is preferred; otherwise fall back to CustomClaims.Decoration().
 type Decorator interface {
 	Decorate() error
 }
 
-// decorate prefers Decorate() and otherwise calls c.Decoration()
+// decorate prefers Decorate() and otherwise calls c.Decoration().
 func decorate(c CustomClaims) error {
 	if d, ok := any(c).(Decorator); ok && d != nil {
 		return d.Decorate()
@@ -122,19 +264,112 @@ func decorate(c CustomClaims) error {
 }
 
 // ============================================================
-// Verification (Preferred APIs)
+// Verification – algorithm-agnostic API (preferred)
 // ============================================================
-// Verify validates a token without enforcing algorithm consistency (same behavior as Check)
+
+// VerifyOptions provides configurable verification options.
+type VerifyOptions struct {
+	// ExpectedAlg enforces the signing algorithm (e.g. "ES256", "RS256", "HS256").
+	ExpectedAlg string
+	// ExpectedIss enforces the token issuer.
+	ExpectedIss string
+	// ExpectedAud enforces the token audience.
+	ExpectedAud string
+	// Leeway allows a small clock skew when validating time-based claims.
+	Leeway time.Duration
+	// KeyFunc provides dynamic key selection (takes priority over PublicKey / verifyKey).
+	KeyFunc jwt.Keyfunc
+	// PublicKey is used for ECDSA verification (kept for backward compatibility).
+	// Prefer verifyKey for multi-algorithm support.
+	PublicKey *ecdsa.PublicKey
+
+	// verifyKey is the internal field used by VerifyWithKey; it accepts any key type.
+	verifyKey interface{}
+}
+
+// VerifyWithOptions validates a JWT token using the supplied options.
+// Supports ECDSA, RSA, and HMAC keys via KeyFunc or the PublicKey / verifyKey fields.
+func VerifyWithOptions(token string, c CustomClaims, opts VerifyOptions) (bool, error) {
+	var kf jwt.Keyfunc
+	switch {
+	case opts.KeyFunc != nil:
+		kf = func(t *jwt.Token) (interface{}, error) {
+			if opts.ExpectedAlg != "" {
+				if t.Method == nil || t.Method.Alg() != opts.ExpectedAlg {
+					return nil, ErrUnexpectedSigningMethod
+				}
+			}
+			return opts.KeyFunc(t)
+		}
+	case opts.verifyKey != nil:
+		expectedAlg := opts.ExpectedAlg
+		vk := opts.verifyKey
+		kf = func(t *jwt.Token) (interface{}, error) {
+			if expectedAlg != "" {
+				if t.Method == nil || t.Method.Alg() != expectedAlg {
+					return nil, ErrUnexpectedSigningMethod
+				}
+			}
+			return vk, nil
+		}
+	case opts.PublicKey != nil:
+		expectedAlg := opts.ExpectedAlg
+		kf = func(t *jwt.Token) (interface{}, error) {
+			if expectedAlg != "" {
+				if t.Method == nil || t.Method.Alg() != expectedAlg {
+					return nil, ErrUnexpectedSigningMethod
+				}
+			}
+			return opts.PublicKey, nil
+		}
+	default:
+		return false, errors.New("one of KeyFunc, PublicKey, or a SigningKey must be provided")
+	}
+
+	// Assemble parser options.
+	var parseOpts []jwt.ParserOption
+	if opts.ExpectedAlg != "" {
+		parseOpts = append(parseOpts, jwt.WithValidMethods([]string{opts.ExpectedAlg}))
+	}
+	if opts.ExpectedIss != "" {
+		parseOpts = append(parseOpts, jwt.WithIssuer(opts.ExpectedIss))
+	}
+	if opts.ExpectedAud != "" {
+		parseOpts = append(parseOpts, jwt.WithAudience(opts.ExpectedAud))
+	}
+	if opts.Leeway > 0 {
+		parseOpts = append(parseOpts, jwt.WithLeeway(opts.Leeway))
+	}
+
+	parsed, err := jwt.ParseWithClaims(token, c, kf, parseOpts...)
+	if err != nil {
+		return false, err
+	}
+	if err := decorate(c); err != nil {
+		return false, err
+	}
+	return parsed.Valid, nil
+}
+
+// ============================================================
+// Verification – ECDSA-only API (preserved for backward compatibility)
+// ============================================================
+
+// Verify validates a token without enforcing algorithm consistency (same behavior as Check).
+//
+// Deprecated: use VerifyWithKey or VerifyWithOptions for clearer naming and multi-algorithm support.
 func Verify(token string, c CustomClaims, key ecdsa.PublicKey) (bool, error) {
 	return Check(token, c, key)
 }
 
-// VerifyWithAlg validates a token and enforces the signing algorithm to match expectedAlg (recommended in production)
+// VerifyWithAlg validates a token and enforces the signing algorithm to match expectedAlg (recommended in production).
+//
+// Deprecated: use VerifyWithKey or VerifyWithOptions.
 func VerifyWithAlg(token string, c CustomClaims, key ecdsa.PublicKey, expectedAlg string) (bool, error) {
 	return CheckSecure(token, c, key, expectedAlg)
 }
 
-// VerifyWithKeyFunc validates a token using a custom keyfunc
+// VerifyWithKeyFunc validates a token using a custom keyfunc.
 func VerifyWithKeyFunc(token string, c CustomClaims, expectedAlg string, keyFunc jwt.Keyfunc) (bool, error) {
 	if keyFunc == nil {
 		return false, errors.New("keyFunc cannot be nil")
@@ -160,10 +395,12 @@ func VerifyWithKeyFunc(token string, c CustomClaims, expectedAlg string, keyFunc
 }
 
 // ============================================================
-// Verification (Legacy APIs)
+// Verification – Legacy APIs
 // ============================================================
+
 // Check validates a JWT token.
-// Deprecated: use Verify or VerifyWithAlg for clearer naming and safer defaults.
+//
+// Deprecated: use VerifyWithKey or VerifyWithAlg for clearer naming and safer defaults.
 func Check(token string, c CustomClaims, key ecdsa.PublicKey) (bool, error) {
 	parse, err := jwt.ParseWithClaims(token, c, func(token *jwt.Token) (interface{}, error) {
 		return &key, nil
@@ -181,6 +418,7 @@ func Check(token string, c CustomClaims, key ecdsa.PublicKey) (bool, error) {
 // 1) Enforces signing algorithm to match expectedAlg (prevents downgrade/misconfiguration).
 // 2) Applies claims.Decoration() for post-processing.
 // Note: expectedAlg like "ES256". If empty, algorithm enforcement is skipped.
+//
 // Deprecated: use VerifyWithAlg instead.
 func CheckSecure(token string, c CustomClaims, key ecdsa.PublicKey, expectedAlg string) (bool, error) {
 	keyFunc := func(tok *jwt.Token) (interface{}, error) {
@@ -204,6 +442,7 @@ func CheckSecure(token string, c CustomClaims, key ecdsa.PublicKey, expectedAlg 
 
 // CheckWithKeyFunc provides strict validation with a custom KeyFunc:
 // allows selecting public keys dynamically (e.g., via header kid) and enforcing expectedAlg.
+//
 // Deprecated: use VerifyWithKeyFunc instead.
 func CheckWithKeyFunc(token string, c CustomClaims, expectedAlg string, keyFunc jwt.Keyfunc) (bool, error) {
 	if keyFunc == nil {
@@ -220,68 +459,6 @@ func CheckWithKeyFunc(token string, c CustomClaims, expectedAlg string, keyFunc 
 	}
 
 	parsed, err := jwt.ParseWithClaims(token, c, wrapped)
-	if err != nil {
-		return false, err
-	}
-	if err := decorate(c); err != nil {
-		return false, err
-	}
-	return parsed.Valid, nil
-}
-
-// VerifyOptions provides configurable verification options
-type VerifyOptions struct {
-	ExpectedAlg string
-	ExpectedIss string
-	ExpectedAud string
-	Leeway      time.Duration
-	KeyFunc     jwt.Keyfunc
-	PublicKey   *ecdsa.PublicKey
-}
-
-// VerifyWithOptions validates using jwt/v5 parser options
-func VerifyWithOptions(token string, c CustomClaims, opts VerifyOptions) (bool, error) {
-	// Build keyfunc
-	var kf jwt.Keyfunc
-	if opts.KeyFunc != nil {
-		kf = func(t *jwt.Token) (interface{}, error) {
-			if opts.ExpectedAlg != "" {
-				if t.Method == nil || t.Method.Alg() != opts.ExpectedAlg {
-					return nil, ErrUnexpectedSigningMethod
-				}
-			}
-			return opts.KeyFunc(t)
-		}
-	} else if opts.PublicKey != nil {
-		expectedAlg := opts.ExpectedAlg
-		kf = func(t *jwt.Token) (interface{}, error) {
-			if expectedAlg != "" {
-				if t.Method == nil || t.Method.Alg() != expectedAlg {
-					return nil, ErrUnexpectedSigningMethod
-				}
-			}
-			return opts.PublicKey, nil
-		}
-	} else {
-		return false, errors.New("either KeyFunc or PublicKey must be provided")
-	}
-
-	// Assemble parser options
-	var parseOpts []jwt.ParserOption
-	if opts.ExpectedAlg != "" {
-		parseOpts = append(parseOpts, jwt.WithValidMethods([]string{opts.ExpectedAlg}))
-	}
-	if opts.ExpectedIss != "" {
-		parseOpts = append(parseOpts, jwt.WithIssuer(opts.ExpectedIss))
-	}
-	if opts.ExpectedAud != "" {
-		parseOpts = append(parseOpts, jwt.WithAudience(opts.ExpectedAud))
-	}
-	if opts.Leeway > 0 {
-		parseOpts = append(parseOpts, jwt.WithLeeway(opts.Leeway))
-	}
-
-	parsed, err := jwt.ParseWithClaims(token, c, kf, parseOpts...)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## 概述 / Summary

修复了在代码审查中发现的 5 个主要设计缺陷。所有改动均保持向后兼容，不破坏现有 API。

## 变更详情 / Changes

### 1. `lifecycle.go` – 用查找表替换双重 switch
**问题**：`emitPluginEvent` 中对 `events.EventType` 进行了两次独立的 switch 转换（一次映射到 `plugins.EventType`，一次映射到 `plugins.PluginStatus`），任何新增事件类型都必须在两处同步修改，容易遗漏。  
**修复**：引入 `lynxToPluginEventTable`（`map[events.EventType]lynxToPluginEventEntry`），将两个映射合并为一条查找表。新增事件类型只需添加一行记录。

### 2. `events/types.go` – 移除每次事件都调用 `crypto/rand` 的做法
**问题**：`generateEventID` 每次生成事件 ID 时都调用 `crypto/rand.Read`，高并发场景下产生大量系统调用，性能开销不必要。  
**修复**：在 `init()` 中一次性生成 8 字节随机盐（`initSalt`）；后续 ID 由 `pluginID + eventType + unixSec + nano + initSalt + counter` 拼接，既保持唯一性，又消除了热路径上的 syscall。

### 3. `cache/cache.go` – 恢复 Ristretto 异步写入语义
**问题**：`Set` 和 `SetWithCost` 在每次写入后强制调用 `c.cache.Wait()`，使 Ristretto 的异步缓冲区形同虚设，写入吞吐量大幅下降。  
**修复**：`Set` / `SetWithCost` 改为纯异步（不调用 `Wait`）；新增 `SetSync` / `SetWithCostSync` 供需要读写一致性的调用方使用；`SetMulti` 保持原有行为（所有 item 写入后统一调用一次 `Wait`），并补充了文档注释。

### 4. `log/logger.go` – 移除 reflect hack，改用 proto accessor
**问题**：`InitLogger` 中用 `reflect.ValueOf` 间接读取 proto 生成结构体的字段（`Format`、`Performance`、`RotationStrategy` 等），注释说明是「等待 proto 重新生成后再改」的临时方案。但 `log.pb.go` 早已包含这些字段的类型安全 accessor（`GetFormat()`、`GetPerformance()` 等）。  
**修复**：将两处 reflect 块替换为直接的 accessor 调用，并移除不再需要的 `"reflect"` import。

### 5. `pkg/auth/jwt/jwt.go` – 支持 RSA 和 HMAC，不再局限于 ECDSA
**问题**：`Sign`、`SignWithOptions` 硬编码只接受 `*ecdsa.PrivateKey` 并强制要求 `ES*` 前缀算法；验证 API 同样仅接受 ECDSA 公钥。  
**修复**：引入 `SigningKey` 接口与对应构造函数（`ECDSAKey`、`RSAKey`、`RSAKeyWithAlg`、`HMACKey`、`HMACKeyWithAlg` 等），新增 `SignWithKey` / `VerifyWithKey` / `SignWithKeyAndOptions` 作为首选 API。`VerifyWithOptions` 扩展了内部 `verifyKey interface{}` 字段以接受任意密钥类型。所有原有 ECDSA 函数保留并标记为 `Deprecated`。

## 影响范围 / Impact

| 文件 | 类型 | 向后兼容 |
|------|------|---------|
| `lifecycle.go` | 重构 | ✅ 是 |
| `events/types.go` | 性能优化 | ✅ 是 |
| `cache/cache.go` | API 扩展 | ✅ 是（Set 语义变更为异步，新增 SetSync） |
| `log/logger.go` | 重构 | ✅ 是 |
| `pkg/auth/jwt/jwt.go` | API 扩展 | ✅ 是（旧 API 保留并标记废弃） |

## 测试说明 / Testing Notes
- 所有更改均为逻辑等价重构或功能扩展，原有测试用例应继续通过。
- `cache.Set` 语义从「同步」改为「异步」——若有测试在 `Set` 后立即 `Get` 并期望命中，需改用 `SetSync`。
- JWT 新 API 可通过新增单元测试覆盖 RSA / HMAC 签发与验证场景。