### PR TITLE
fix(circuit_breaker): eliminate RWMutex lock-upgrade race in CanExecute

### DIFF
--- a/circuit_breaker.go
+++ b/circuit_breaker.go
@@ -2,13 +2,38 @@ package lynx
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 // CircuitBreaker provides error handling and recovery.
+//
+// Concurrency design
+// ──────────────────
+// State transitions are the only write path that previously required a
+// read-lock → write-lock "upgrade" – a pattern that is fundamentally
+// unsafe in Go's sync.RWMutex (there is no atomic upgrade; the caller
+// must release the read-lock first, creating a window where another
+// goroutine can observe an inconsistent state or perform the same
+// transition).
+//
+// The fix replaces the mutable `state` field with an atomic int32 and
+// uses a compare-and-swap (CAS) to transition Open → HalfOpen.  Only
+// one goroutine wins the CAS; all others see HalfOpen and return true
+// without touching the state again.  The remaining counters and
+// lastFailure are still guarded by a plain sync.Mutex because they are
+// always written together.
+//
+// Rule of thumb for future changes:
+//   - Read/write `state` ONLY through atomicLoadState / atomicStoreState /
+//     atomicCASState.  Never hold `mu` while calling those helpers.
+//   - Read/write failureCount, successCount, lastFailure ONLY while
+//     holding `mu`.
 type CircuitBreaker struct {
-	mu           sync.RWMutex
-	state        CircuitState
+	// state is accessed exclusively via atomic helpers; see rule above.
+	state int32 // stores a CircuitState value
+
+	mu           sync.Mutex
 	failureCount int
 	successCount int
 	lastFailure  time.Time
@@ -17,13 +42,31 @@ type CircuitBreaker struct {
 }
 
 // CircuitState represents the state of circuit breaker.
-type CircuitState int
+type CircuitState int32
 
 const (
-	CircuitStateClosed CircuitState = iota
-	CircuitStateOpen
-	CircuitStateHalfOpen
+	CircuitStateClosed   CircuitState = iota // 0 – normal operation
+	CircuitStateOpen                         // 1 – requests rejected
+	CircuitStateHalfOpen                     // 2 – one probe allowed
 )
+
+// ── atomic helpers ────────────────────────────────────────────────────────────
+
+func (cb *CircuitBreaker) atomicLoadState() CircuitState {
+	return CircuitState(atomic.LoadInt32(&cb.state))
+}
+
+func (cb *CircuitBreaker) atomicStoreState(s CircuitState) {
+	atomic.StoreInt32(&cb.state, int32(s))
+}
+
+// atomicCASState transitions from old → new atomically.
+// Returns true if the swap happened (this goroutine "won").
+func (cb *CircuitBreaker) atomicCASState(old, new CircuitState) bool {
+	return atomic.CompareAndSwapInt32(&cb.state, int32(old), int32(new))
+}
+
+// ── public API ────────────────────────────────────────────────────────────────
 
 // NewCircuitBreaker creates a new circuit breaker with the provided threshold and timeout.
 func NewCircuitBreaker(threshold int, timeout time.Duration) *CircuitBreaker {
@@ -33,33 +76,47 @@ func NewCircuitBreaker(threshold int, timeout time.Duration) *CircuitBreaker {
 	if timeout <= 0 {
 		timeout = time.Second
 	}
-	return &CircuitBreaker{
-		state:     CircuitStateClosed,
+	cb := &CircuitBreaker{
 		threshold: threshold,
 		timeout:   timeout,
 	}
+	cb.atomicStoreState(CircuitStateClosed)
+	return cb
 }
 
 // CanExecute checks if the circuit breaker allows execution.
+//
+// Concurrency safety
+// ──────────────────
+// The Open → HalfOpen transition is a single CAS.  Exactly one goroutine
+// wins; all others observe HalfOpen and return true without a second
+// state write.  There is no lock-upgrade race and no defer/manual-unlock
+// mismatch.
 func (cb *CircuitBreaker) CanExecute() bool {
-	cb.mu.RLock()
-	defer cb.mu.RUnlock()
-
-	switch cb.state {
+	switch cb.atomicLoadState() {
 	case CircuitStateClosed:
 		return true
+
 	case CircuitStateOpen:
-		if time.Since(cb.lastFailure) >= cb.timeout {
-			cb.mu.RUnlock()
-			cb.mu.Lock()
-			cb.state = CircuitStateHalfOpen
-			cb.mu.Unlock()
-			cb.mu.RLock()
+		// Read lastFailure under mu to avoid a data race: RecordResult
+		// writes it under the same lock.
+		cb.mu.Lock()
+		elapsed := time.Since(cb.lastFailure)
+		cb.mu.Unlock()
+
+		if elapsed >= cb.timeout {
+			// Only one goroutine transitions Open → HalfOpen.
+			// If the CAS fails, another goroutine already made the
+			// transition (or RecordResult moved state elsewhere); in
+			// either case the state is no longer Open, so allow execution.
+			cb.atomicCASState(CircuitStateOpen, CircuitStateHalfOpen)
 			return true
 		}
 		return false
+
 	case CircuitStateHalfOpen:
 		return true
+
 	default:
 		return false
 	}
@@ -74,21 +131,26 @@ func (cb *CircuitBreaker) RecordResult(err error) {
 		cb.failureCount++
 		cb.lastFailure = time.Now()
 
-		if cb.state == CircuitStateClosed && cb.failureCount >= cb.threshold {
-			cb.state = CircuitStateOpen
-		} else if cb.state == CircuitStateHalfOpen {
-			cb.state = CircuitStateOpen
+		switch cb.atomicLoadState() {
+		case CircuitStateClosed:
+			if cb.failureCount >= cb.threshold {
+				cb.atomicStoreState(CircuitStateOpen)
+			}
+		case CircuitStateHalfOpen:
+			cb.atomicStoreState(CircuitStateOpen)
 		}
 	} else {
 		cb.successCount++
 
-		if cb.state == CircuitStateHalfOpen {
-			cb.state = CircuitStateClosed
+		if cb.atomicLoadState() == CircuitStateHalfOpen {
+			cb.atomicStoreState(CircuitStateClosed)
 			cb.resetCounters()
 		}
 	}
 }
 
+// resetCounters resets the failure and success counts.
+// MUST be called with cb.mu held.
 func (cb *CircuitBreaker) resetCounters() {
 	cb.failureCount = 0
 	cb.successCount = 0
@@ -96,7 +158,5 @@ func (cb *CircuitBreaker) resetCounters() {
 
 // GetState returns the current circuit breaker state.
 func (cb *CircuitBreaker) GetState() CircuitState {
-	cb.mu.RLock()
-	defer cb.mu.RUnlock()
-	return cb.state
+	return cb.atomicLoadState()
 }

--- a/circuit_breaker_test.go
+++ b/circuit_breaker_test.go
@@ -1,6 +1,7 @@
 package lynx
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -57,6 +58,10 @@ func TestCircuitBreaker_StateTransitions(t *testing.T) {
 	}
 }
 
+// TestCircuitBreaker_ConcurrentCanExecuteAfterTimeout verifies that when many
+// goroutines call CanExecute simultaneously after the open timeout expires,
+// the breaker transitions to HalfOpen exactly once (via CAS) and no panic or
+// double-unlock occurs.  Run with -race to catch data races.
 func TestCircuitBreaker_ConcurrentCanExecuteAfterTimeout(t *testing.T) {
 	cb := NewCircuitBreaker(1, 5*time.Millisecond)
 	cb.RecordResult(fmt.Errorf("boom"))
@@ -77,8 +82,41 @@ func TestCircuitBreaker_ConcurrentCanExecuteAfterTimeout(t *testing.T) {
 	}
 	wg.Wait()
 
+	// After the timeout all goroutines should see HalfOpen (or have raced
+	// through it and been closed by RecordResult, but since we did not
+	// call RecordResult here it must still be HalfOpen).
 	if cb.GetState() != CircuitStateHalfOpen {
 		t.Fatalf("expected breaker to stabilize in half-open, got %v", cb.GetState())
+	}
+}
+
+// TestCircuitBreaker_NoPanicOnConcurrentTransition is a targeted regression
+// test for the original double-unlock bug.  It checks that no panic occurs
+// when hundreds of goroutines hammer CanExecute just as the timeout fires.
+func TestCircuitBreaker_NoPanicOnConcurrentTransition(t *testing.T) {
+	const rounds = 20
+	for r := 0; r < rounds; r++ {
+		cb := NewCircuitBreaker(1, time.Millisecond)
+		cb.RecordResult(errors.New("err"))
+
+		// Spin up goroutines before the timeout fires so some race the transition.
+		const n = 64
+		var wg sync.WaitGroup
+		wg.Add(n)
+		// Small sleep so the timeout is imminent but not necessarily expired.
+		time.Sleep(500 * time.Microsecond)
+		for i := 0; i < n; i++ {
+			go func() {
+				defer wg.Done()
+				_ = cb.CanExecute()
+			}()
+		}
+		wg.Wait()
+		// State must be Open or HalfOpen; Closed is impossible without a success.
+		st := cb.GetState()
+		if st != CircuitStateOpen && st != CircuitStateHalfOpen {
+			t.Fatalf("round %d: unexpected state %v", r, st)
+		}
 	}
 }
 
@@ -148,6 +186,8 @@ func TestCircuitBreaker_ResetCountersOnClose(t *testing.T) {
 	}
 }
 
+// TestCircuitBreaker_GetState_DataRace runs with -race to verify no data race
+// when RecordResult and GetState are called concurrently.
 func TestCircuitBreaker_GetState_DataRace(t *testing.T) {
 	cb := NewCircuitBreaker(5, 5*time.Millisecond)
 	var wg sync.WaitGroup
@@ -166,4 +206,43 @@ func TestCircuitBreaker_GetState_DataRace(t *testing.T) {
 	}
 	wg.Wait()
 	// No assertions needed — test verifies no data race with -race flag.
+}
+
+// TestCircuitBreaker_FullConcurrency hammers all three public methods
+// concurrently to exercise every concurrent path.  Run with -race.
+func TestCircuitBreaker_FullConcurrency(t *testing.T) {
+	cb := NewCircuitBreaker(3, 5*time.Millisecond)
+	var wg sync.WaitGroup
+	const n = 100
+
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			switch idx % 3 {
+			case 0:
+				_ = cb.CanExecute()
+			case 1:
+				cb.RecordResult(fmt.Errorf("concurrent-err"))
+			case 2:
+				cb.RecordResult(nil)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// TestCircuitBreaker_OpenRejectsBeforeTimeout asserts that an open breaker
+// rejects calls before the timeout elapses (no accidental early transition).
+func TestCircuitBreaker_OpenRejectsBeforeTimeout(t *testing.T) {
+	cb := NewCircuitBreaker(1, 10*time.Second) // long timeout
+	cb.RecordResult(errors.New("err"))
+	if cb.GetState() != CircuitStateOpen {
+		t.Fatalf("expected open state, got %v", cb.GetState())
+	}
+	for i := 0; i < 5; i++ {
+		if cb.CanExecute() {
+			t.Fatal("open breaker with long timeout must reject execution")
+		}
+	}
 }


### PR DESCRIPTION
## Problem

The original `CanExecute()` had **two concurrent-safety bugs** in the `CircuitStateOpen` branch:

### Bug 1 — Double-unlock → panic
```go
cb.mu.RLock()
defer cb.mu.RUnlock()   // ← registered

case CircuitStateOpen:
    cb.mu.RUnlock()     // ← manual unlock #1
    cb.mu.Lock()
    cb.state = CircuitStateHalfOpen
    cb.mu.Unlock()
    cb.mu.RLock()
    return true
// function returns → defer fires → RUnlock on already-unlocked mutex → PANIC
```

### Bug 2 — TOCTOU race (Open → HalfOpen window)
Between releasing `RUnlock()` and acquiring `Lock()`, N goroutines that all passed the `time.Since(cb.lastFailure) >= cb.timeout` check race to write `CircuitStateHalfOpen`. All N win — each sets the state independently with no coordination.

## Fix

Replace the `sync.RWMutex`-guarded `int` state with an **atomic `int32`**.

The Open → HalfOpen transition is now a single **Compare-And-Swap**:
- Exactly **one** goroutine wins the CAS; all others observe `HalfOpen` and return `true` without a second write.
- No lock-upgrade is needed → no defer/manual-unlock mismatch.
- `lastFailure` (a `time.Time`) is still read under `cb.mu` (plain `sync.Mutex`) to avoid a data race — `RecordResult` writes it under the same lock.
- `sync.RWMutex` downgraded to `sync.Mutex` (the only reason for a read-write lock was the now-removed `GetState()` / `CanExecute()` read path).

## Changed files

| File | Change |
|---|---|
| `circuit_breaker.go` | Atomic state field, CAS transition, helper methods, doc comment |
| `circuit_breaker_test.go` | +3 new tests: `NoPanicOnConcurrentTransition`, `FullConcurrency`, `OpenRejectsBeforeTimeout` |

## How to verify

```bash
go test -race -count=1 -run TestCircuitBreaker ./...
```

All 9 circuit-breaker tests should pass with no race detector warnings.